### PR TITLE
Change memmap order

### DIFF
--- a/calciumcurator/calcium_curator.py
+++ b/calciumcurator/calcium_curator.py
@@ -30,7 +30,10 @@ def calcium_curator(
         # add the SNR widgets
         if (snr_mask is not None) and (snr is not None):
             snr_image = viewer.add_image(snr_mask, visible=False)
-            bins = np.linspace(np.int(snr.min()), np.int(snr.max()), 20)
+            snr_clean = np.nan_to_num(snr, copy=True, neginf=0, nan=0)
+            bins = np.linspace(
+                np.rint(snr_clean.min()), np.rint(snr_clean.max()), 20
+            )
             y, x = np.histogram(snr, bins=bins)
             hist = HistogramWidget(x, y, xlabel="SNR", ylabel="counts")
 

--- a/calciumcurator/io/caiman/caiman_reader.py
+++ b/calciumcurator/io/caiman/caiman_reader.py
@@ -31,7 +31,7 @@ def load_movie(filename: str):
     """
     # filename = os.path.basename(filename)
     Yr, dims, T = load_memmap(filename)
-    images = np.reshape(Yr.T, [T] + list(dims), order="F")
+    images = np.reshape(Yr.T, [T] + list(dims), order="C")
 
     return images
 

--- a/calciumcurator/io/caiman/caiman_reader.py
+++ b/calciumcurator/io/caiman/caiman_reader.py
@@ -54,6 +54,8 @@ def caiman_reader(
 
     # make the contours
     estimates = cnm_obj["estimates"]
+    if estimates["dims"] is None:
+        estimates["dims"] = im_registered.shape[1::]
     img_components = (
         estimates["A"]
         .toarray()


### PR DESCRIPTION
Change the memmap order for the registered movie to "C", which should make reading time slices much faster.