### PR TITLE
lock y axis zoom on line plots

### DIFF
--- a/calciumcurator/qt/plots.py
+++ b/calciumcurator/qt/plots.py
@@ -52,6 +52,7 @@ class LinePlotWidget(QWidget):
             curve_item = pg.PlotCurveItem(x, y)
             self._plot.addItem(curve_item)
             self._curves.append(curve_item)
+        self._plot.plotItem.setMouseEnabled(y=False)
         self.vbox.addWidget(new_plot)
 
     def add_events(self, events, f_trace):


### PR DESCRIPTION
This pull request changes the pan/zoom interaction on the line plots such that the y axis is locked. This makes it easier to inspect peaks in long time series data.