### PR TITLE
Fix caiman loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py
-napari[all]
+napari[all]==0.3.8
 numpy
 pyqtgraph
 scikit-image


### PR DESCRIPTION
This fixes two bugs:
- the caiman hdf5 file dims field wasn't being loaded properly
- inf snr values cause a bug with the image display. inf is  now replaced with the max SNR value 